### PR TITLE
Set MA0016 to none in test projects

### DIFF
--- a/distribution/test/.editorconfig
+++ b/distribution/test/.editorconfig
@@ -20,7 +20,7 @@
 # Meziantou
 # https://www.meziantou.net/enforcing-asynchronous-code-good-practices-using-a-roslyn-analyzer.htm
 dotnet_diagnostic.MA0004.severity = none            # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/Meziantou/MA0004.md
-dotnet_diagnostic.MA0016.severity = none            # MA0016: Prefer return collection abstraction instead of implementation
+dotnet_diagnostic.MA0016.severity = none            # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/Meziantou/MA0016.md
 
 # Microsoft - Code Analysis
 # https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/

--- a/distribution/test/.editorconfig
+++ b/distribution/test/.editorconfig
@@ -20,6 +20,7 @@
 # Meziantou
 # https://www.meziantou.net/enforcing-asynchronous-code-good-practices-using-a-roslyn-analyzer.htm
 dotnet_diagnostic.MA0004.severity = none            # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/Meziantou/MA0004.md
+dotnet_diagnostic.MA0016.severity = none            # MA0016: Prefer return collection abstraction instead of implementation
 
 # Microsoft - Code Analysis
 # https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/

--- a/documentation/CodeAnalyzersRules/Meziantou/MA0016.md
+++ b/documentation/CodeAnalyzersRules/Meziantou/MA0016.md
@@ -38,4 +38,4 @@ Just follow the rule - see 'How to fix violations'
 
 ### Reason & arguments
 
-* The majority voted for the use of interfaces.
+* The majority voted for the use of interfaces in production code, but set this rule to NONE in test projects.


### PR DESCRIPTION
I am pretty sure we agreed that this rule should only be enforced in production code, not in test code. Looking at the comments in #12 it is noted in the second to last comment that it was the decision.

In a test project, it does not make much sense to enforce using abstractions such as `IReadOnlyLIst` vs `List` as we are not designing an API for external consumption.