### PR TITLE
Set ps1 files to have a standard indent of 2 and use linux line endings

### DIFF
--- a/distribution/.editorconfig
+++ b/distribution/.editorconfig
@@ -54,9 +54,10 @@ indent_size = 2
 [*.{cmd,bat}]
 end_of_line = crlf
 
-# Bash Files
-[*.sh]
+# Shell scripts/files
+[*.{sh,ps1}]
 end_of_line = lf
+indent_size = 2
 
 # Makefiles
 [Makefile]


### PR DESCRIPTION
This ensures consistent indentation in ps1 files, and, since we have started to run our powershell scripts on linux as well, it makes sense to normalize to linux line endings to ensure ps1 files works in all environments.