### PR TITLE
Upgrade to C# 10, file scoped namespaces, global usings

### DIFF
--- a/distribution/.editorconfig
+++ b/distribution/.editorconfig
@@ -252,6 +252,7 @@ csharp_space_between_square_brackets = false
 # https://docs.microsoft.com/visualstudio/ide/editorconfig-formatting-conventions#wrap-options
 csharp_preserve_single_line_statements = false
 csharp_preserve_single_line_blocks = true
+csharp_style_namespace_declarations = file_scoped:warning
 
 ##########################################
 # .NET Naming Conventions

--- a/distribution/Directory.Build.props
+++ b/distribution/Directory.Build.props
@@ -17,6 +17,7 @@
   <PropertyGroup Label="Compile settings">
     <Nullable>enable</Nullable>
     <LangVersion>10.0</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>   
     <TargetFramework>net6.0</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>1573,1591,1712,CA1014</NoWarn>

--- a/distribution/Directory.Build.props
+++ b/distribution/Directory.Build.props
@@ -16,7 +16,8 @@
 
   <PropertyGroup Label="Compile settings">
     <Nullable>enable</Nullable>
-    <LangVersion>9.0</LangVersion>
+    <LangVersion>10.0</LangVersion>
+    <TargetFramework>net6.0</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>1573,1591,1712,CA1014</NoWarn>
 

--- a/distribution/Directory.Build.props
+++ b/distribution/Directory.Build.props
@@ -42,11 +42,10 @@
   <ItemGroup Label="Code Analyzers">
     <PackageReference Include="AsyncFixer" Version="1.5.1" PrivateAssets="All" />
     <PackageReference Include="Asyncify" Version="0.9.7" PrivateAssets="All" />
-    <PackageReference Include="Meziantou.Analyzer" Version="1.0.666" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="5.0.3" PrivateAssets="All" />
-    <PackageReference Include="SecurityCodeScan.VS2019" Version="5.1.0" PrivateAssets="All" />
+    <PackageReference Include="Meziantou.Analyzer" Version="1.0.676" PrivateAssets="All" />
+    <PackageReference Include="SecurityCodeScan.VS2019" Version="5.2.1" PrivateAssets="All" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="All" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.24.0.32949" PrivateAssets="All" />
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.32.0.39516" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>

--- a/distribution/src/Directory.Build.props
+++ b/distribution/src/Directory.Build.props
@@ -8,7 +8,6 @@
 
   <PropertyGroup Label="Build instructions">
     <OutputType>Library</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
     <!-- Creates a regular package and a symbols package -->
     <IncludeSymbols>true</IncludeSymbols>
     <!-- Creates symbol package in the new .snupkg format -->

--- a/distribution/test/Directory.Build.props
+++ b/distribution/test/Directory.Build.props
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup Label="Test Analyzers">
-    <PackageReference Include="NSubstitute.Analyzers.CSharp" Version="1.0.14" PrivateAssets="All" />
+    <PackageReference Include="NSubstitute.Analyzers.CSharp" Version="1.0.15" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>

--- a/distribution/test/Directory.Build.props
+++ b/distribution/test/Directory.Build.props
@@ -10,7 +10,8 @@
     <Nullable>annotations</Nullable>
   </PropertyGroup>
 
-  <ItemGroup Label="Test Analyzers">
+  <ItemGroup>
+    <PackageReference Include="Atc.Test" Version="1.0.45" />
     <PackageReference Include="NSubstitute.Analyzers.CSharp" Version="1.0.15" PrivateAssets="All" />
   </ItemGroup>
 

--- a/distribution/test/Directory.Build.props
+++ b/distribution/test/Directory.Build.props
@@ -16,7 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Using Include="Atc.test" />
+    <Using Include="Atc.Test" />
     <Using Include="AutoFixture" />
     <Using Include="AutoFixture.Xunit2" />
     <Using Include="FluentAssertions" />

--- a/distribution/test/Directory.Build.props
+++ b/distribution/test/Directory.Build.props
@@ -14,4 +14,10 @@
     <PackageReference Include="NSubstitute.Analyzers.CSharp" Version="1.0.15" PrivateAssets="All" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Using Include="FluentAssertions" />
+    <Using Include="NSubstitute" />
+    <Using Include="Xunit" />
+  </ItemGroup>
+
 </Project>

--- a/distribution/test/Directory.Build.props
+++ b/distribution/test/Directory.Build.props
@@ -15,6 +15,8 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Using Include="AutoFixture" />
+    <Using Include="AutoFixture.Xunit2" />
     <Using Include="FluentAssertions" />
     <Using Include="NSubstitute" />
     <Using Include="Xunit" />

--- a/distribution/test/Directory.Build.props
+++ b/distribution/test/Directory.Build.props
@@ -15,6 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Using Include="Atc.test" />
     <Using Include="AutoFixture" />
     <Using Include="AutoFixture.Xunit2" />
     <Using Include="FluentAssertions" />


### PR DESCRIPTION
This includes a bunch of tweaks and improvements made available with C# 10.

- File scoped name scoped name sapces
- Global usings enabled
- Default usings included for test projects
- Upgrade to analyzers
- Removes the redundant `Microsoft.CodeAnalysis.NetAnalyzers` analyzer as this is now build into the SDK.

To automatically format an entire solution to use file scoped namespaces, just apply these changes, and run `dotnet format style` from the command line.

More info here: https://ardalis.com/dotnet-format-and-file-scoped-namespaces/