### PR TITLE
Add section in editorconfigs for custom normal rules

### DIFF
--- a/distribution/dotnet5/.editorconfig
+++ b/distribution/dotnet5/.editorconfig
@@ -1,6 +1,6 @@
 # ATC coding rules - https://github.com/atc-net/atc-coding-rules
-# Version: 1.0.7
-# Updated: 18-06-2021
+# Version: 1.0.8
+# Updated: 01-02-2022
 # Location: Root
 # Inspired by: https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/code-style-rule-options
 
@@ -484,6 +484,10 @@ dotnet_diagnostic.SA1649.severity = error           # https://github.com/atc-net
 # SonarAnalyzer.CSharp
 # https://rules.sonarsource.com/csharp
 dotnet_diagnostic.S1135.severity = suggestion       # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/SonarAnalyzerCSharp/S1135.md
+
+##########################################
+# Custom - File Extension Settings
+##########################################
 
 
 ##########################################

--- a/distribution/dotnet6/.editorconfig
+++ b/distribution/dotnet6/.editorconfig
@@ -1,6 +1,6 @@
 # ATC coding rules - https://github.com/atc-net/atc-coding-rules
-# Version: 1.0.7
-# Updated: 18-06-2021
+# Version: 1.0.8
+# Updated: 01-02-2022
 # Location: Root
 # Inspired by: https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/code-style-rule-options
 
@@ -485,6 +485,10 @@ dotnet_diagnostic.SA1649.severity = error           # https://github.com/atc-net
 # SonarAnalyzer.CSharp
 # https://rules.sonarsource.com/csharp
 dotnet_diagnostic.S1135.severity = suggestion       # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/SonarAnalyzerCSharp/S1135.md
+
+##########################################
+# Custom - File Extension Settings
+##########################################
 
 
 ##########################################

--- a/distribution/dotnetcore/.editorconfig
+++ b/distribution/dotnetcore/.editorconfig
@@ -1,6 +1,6 @@
 # ATC coding rules - https://github.com/atc-net/atc-coding-rules
-# Version: 1.0.7
-# Updated: 18-06-2021
+# Version: 1.0.8
+# Updated: 01-02-2022
 # Location: Root
 # Inspired by: https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/code-style-rule-options
 
@@ -484,6 +484,10 @@ dotnet_diagnostic.SA1649.severity = error           # https://github.com/atc-net
 # SonarAnalyzer.CSharp
 # https://rules.sonarsource.com/csharp
 dotnet_diagnostic.S1135.severity = suggestion       # https://github.com/atc-net/atc-coding-rules/blob/main/documentation/CodeAnalyzersRules/SonarAnalyzerCSharp/S1135.md
+
+##########################################
+# Custom - File Extension Settings
+##########################################
 
 
 ##########################################


### PR DESCRIPTION
Since the updater overwrites the top section defining e.g. indent size
for various file types, we should have a dedicated section for overriding
normal (not coding-rule related) .editorconfig configurations.

I have placed these new sections at the very bottom, because I can't remember how 
"intelligent" the coding-rules-updater is regarding ordering of sections, so feel
free to move it elsewhere. Ideally a location right after the 
"default" File Extensions settings block (e.g. around line 65) would be 
preferred if the tool allows this. (IMHO)