### PR TITLE
Update Stylecop.Analyzers version to support Record style naming

### DIFF
--- a/distribution/dotnet6/Directory.Build.props
+++ b/distribution/dotnet6/Directory.Build.props
@@ -45,7 +45,7 @@
     <PackageReference Include="Asyncify" Version="0.9.7" PrivateAssets="All" />
     <PackageReference Include="Meziantou.Analyzer" Version="1.0.694" PrivateAssets="All" />
     <PackageReference Include="SecurityCodeScan.VS2019" Version="5.6.0" PrivateAssets="All" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="All" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.435" PrivateAssets="All" />
     <PackageReference Include="SonarAnalyzer.CSharp" Version="8.33.0.40503" PrivateAssets="All" />
   </ItemGroup>
 


### PR DESCRIPTION
Update Stylecop analyzer to support Record style naming. No non-beta version currently exists that support this :( 